### PR TITLE
rename php71 to php7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+inventory-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - "ansible-playbook tests/test.yml -i tests/inventory --connection=local"
   - /usr/sbin/php-fpm --version
   - /usr/sbin/php-fpm -m
-  - cat /etc/php71/fpm/fpm.conf
+  - cat /etc/php7.1/fpm/fpm.conf
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/files/logrotate
+++ b/files/logrotate
@@ -8,6 +8,6 @@
   nocreate
   sharedscripts
   postrotate
-    [ ! -f /run/php71-fpm.pid ] || kill -USR1 `cat /run/php71-fpm.pid`
+    [ ! -f /run/php7.1-fpm.pid ] || kill -USR1 `cat /run/php7.1-fpm.pid`
   endscript
 }

--- a/files/php-fpm.init.conf
+++ b/files/php-fpm.init.conf
@@ -10,9 +10,9 @@
 # Description:       starts the PHP FastCGI Process Manager daemon
 ### END INIT INFO
 
-php_fpm_BIN=/opt/php71/sbin/php-fpm
-php_fpm_CONF=/etc/php71/fpm/fpm.conf
-php_fpm_PID=/run/php71-fpm.pid
+php_fpm_BIN=/opt/php7.1/sbin/php-fpm
+php_fpm_CONF=/etc/php7.1/fpm/fpm.conf
+php_fpm_PID=/run/php7.1-fpm.pid
 
 
 php_opts="--fpm-config $php_fpm_CONF --pid $php_fpm_PID"

--- a/files/php-fpm.service.conf
+++ b/files/php-fpm.service.conf
@@ -4,8 +4,8 @@ After=syslog.target network.target
 
 [Service]
 Type=notify
-PIDFile=/run/php71-fpm.pid
-ExecStart=/opt/php71/sbin/php-fpm --nodaemonize --fpm-config /etc/php71/fpm/fpm.conf
+PIDFile=/run/php7.1-fpm.pid
+ExecStart=/opt/php7.1/sbin/php-fpm --nodaemonize --fpm-config /etc/php7.1/fpm/fpm.conf
 ExecReload=/bin/kill -USR2 $MAINPID
 Restart=on-failure
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
 
 - name: restart_php7_fpm
   service:
-    name: php71-fpm
+    name: php7.1-fpm
     state: restarted
     enabled: yes
   become: yes

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,10 +7,10 @@
     recurse: no
     path: "{{ item }}"
   with_items:
-  - /etc/php71
-  - /etc/php71/fpm
-  - /etc/php71/fpm/conf.d
-  - /etc/php71/fpm/pool.d
+  - /etc/php7.1
+  - /etc/php7.1/fpm
+  - /etc/php7.1/fpm/conf.d
+  - /etc/php7.1/fpm/pool.d
   - /var/www
   - /var/log/php7-fpm
   become: yes
@@ -21,22 +21,22 @@
   become: yes
 
 - name: Create php.ini
-  template: src=php.ini dest=/etc/php71/fpm/php.ini mode=0644
+  template: src=php.ini dest=/etc/php7.1/fpm/php.ini mode=0644
   become: yes
   notify: restart_php7_fpm
 
 - name: Add logrotate config
-  copy: src=logrotate dest=/etc/logrotate.d/php71-fpm mode=0644
+  copy: src=logrotate dest=/etc/logrotate.d/php7.1-fpm mode=0644
   become: yes
   notify: restart_php7_fpm
 
 - name: Add fpm config
-  template: src=php-fpm.conf dest=/etc/php71/fpm/fpm.conf
+  template: src=php-fpm.conf dest=/etc/php7.1/fpm/fpm.conf
   become: yes
   notify: restart_php7_fpm
 
 - name: Add default fpm pool
-  copy: src=default.conf dest=/etc/php71/fpm/pool.d/default.conf
+  copy: src=default.conf dest=/etc/php7.1/fpm/pool.d/default.conf
   become: yes
   notify: restart_php7_fpm
 
@@ -46,7 +46,7 @@
   ignore_errors: yes
 
 - name: Add php-fpm.service
-  copy: src=php-fpm.service.conf dest=/lib/systemd/system/php71-fpm.service mode=0644
+  copy: src=php-fpm.service.conf dest=/lib/systemd/system/php7.1-fpm.service mode=0644
   become: yes
   when: systemctl_version.rc == 0
   notify: restart_php7_fpm
@@ -57,7 +57,7 @@
   become: yes
 
 - name: Add php-fpm.init
-  copy: src=php-fpm.init.conf dest=/etc/init.d/php71-fpm mode="a+x"
+  copy: src=php-fpm.init.conf dest=/etc/init.d/php7.1-fpm mode="a+x"
   become: yes
   when: systemctl_version.rc != 0
   notify: restart_php7_fpm

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -2,7 +2,7 @@
 
 - name: replace default locations with php7
   file:
-    src: /opt/php71/sbin/php-fpm
+    src: /opt/php7.1/sbin/php-fpm
     dest: /usr/sbin/php-fpm
     owner: root
     group: root

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -7,4 +7,5 @@
     owner: root
     group: root
     state: link
+    force: yes
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   include_tasks: packages-{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}.yml
 
 - name: get php-fpm version
-  command: /opt/php71/sbin/php-fpm --version
+  command: /opt/php7.1/sbin/php-fpm --version
   register: php7fpm_current
   ignore_errors: yes
 

--- a/templates/php-fpm.conf
+++ b/templates/php-fpm.conf
@@ -3,7 +3,7 @@
 ;;;;;;;;;;;;;;;;;;;;;
 
 [global]
-pid = /run/php71-fpm.pid
+pid = /run/php7.1-fpm.pid
 {% if php7fpm_error_log is defined %}
 error_log = "{{ php7fpm_error_log }}"
 {% endif %}
@@ -27,4 +27,4 @@ events.mechanism = epoll
 ;;;;;;;;;;;;;;;;;;;;
 ; Pool Definitions ;
 ;;;;;;;;;;;;;;;;;;;;
-include=/etc/php71/fpm/pool.d/*.conf
+include=/etc/php7.1/fpm/pool.d/*.conf

--- a/templates/php.ini
+++ b/templates/php.ini
@@ -64,7 +64,7 @@ session.gc_maxlifetime = 2592000
 session.serialize_handler = igbinary
 
 ; opcache
-zend_extension = /opt/php71/lib/php/extensions/no-debug-non-zts-20160303/opcache.so
+zend_extension = /opt/php7.1/lib/php/extensions/no-debug-non-zts-20160303/opcache.so
 opcache.memory_consumption = {{ php7fpm_conf_opcache_memory_consumption }}
 opcache.interned_strings_buffer = 16
 opcache.max_accelerated_files = 32531


### PR DESCRIPTION
newrelic installation script does not accept this naming convention:

/usr/lib/newrelic-php5/newrelic-install.sh

Ubuntu 13.10 has separate Apache, CLI and FPM configuration directories,
but our detection algorithms currently only detect the CLI directory. As a
stopgap, let's detect that situation and set ${pi_inidir_dso} so that the
INI file gets installed to the right place.
  `for cfg_pfx in /etc/php5 /etc/php7 /etc/php/[57].*; do`